### PR TITLE
URC-334: fix software deploy from x86 computers

### DIFF
--- a/softwareUpdate/urc_deploy.py
+++ b/softwareUpdate/urc_deploy.py
@@ -3,14 +3,14 @@ import subprocess
 import argparse
 import os
 import threading
+import pathlib
 
 USERNAME = 'lusi'
 PASSWORD = 'lusi'
 MAIN_COMPUTER_IP = '10.0.0.10'
 DRIVELINE_COMPUTER_IP = '10.0.0.20'
 MAIN_COMPUTER_PATH = '/home/lusi/urc_software_deploy'
-# LOCAL_PATH = '/mnt/c/Users/phamd/urc_software'
-LOCAL_PATH = '/home/parallels/lusi/urc_software'
+LOCAL_PATH = pathlib.Path(__file__).parent.parent.resolve()
 DOCKER_IMAGE_NAME = 'urc_software'
 
 def rsync_files():
@@ -32,6 +32,8 @@ def rsync_files():
         f'--exclude=".gitconfig" '
         f'--exclude="imgui.ini" '
         f'--exclude="nul" '
+        f'--exclude="libs/pigpio/*.so*" '
+        f'--exclude="libs/pigpio/*.o" '
         f'{LOCAL_PATH}/ {USERNAME}@{MAIN_COMPUTER_IP}:{MAIN_COMPUTER_PATH}/'
     )
     subprocess.run(rsync_command, shell=True)


### PR DESCRIPTION
See title.

Fixes problem where a version of the `pigpio` library is passed from the host computer to the Jetson during a deploy. This ment that if the host computer was not `arm64` than the build would fail. This PR adds add rsync ignore flags to ignore any `.o` and `.so*` files allowing the `pigpen` library to be built locally on the Jetson no matter what has been built on the host machine.

There is also a ride along fix where @tip226 previously hard coded the host directory to rsync during a deploy. Now this directory is found at runtime from the grandparent directory of the python file.